### PR TITLE
optimization of "O"

### DIFF
--- a/src/lib/definitions.js
+++ b/src/lib/definitions.js
@@ -850,6 +850,7 @@ function getFHPaddingEntries(index)
         'O':
         [
             define('(RP_3_WA + PLAIN_OBJECT)[11]'),
+            defineCharAtFnPos('Object', 9),
             define('btoa(NaN)[3]', ATOB),
             define('"".fontcolor()[2]', CAPITAL_HTML),
             define('(RP_3_WA + Intl)[11]', PLAIN_INTL),
@@ -1208,6 +1209,7 @@ function getFHPaddingEntries(index)
         [
             define('PLAIN_OBJECT.constructor'),
             define('Intl.constructor', INTL),
+            define('[].entries.constructor', ARRAY_ITERATOR),
         ],
         RegExp:
         [

--- a/src/lib/definitions.js
+++ b/src/lib/definitions.js
@@ -1209,7 +1209,7 @@ function getFHPaddingEntries(index)
         [
             define('PLAIN_OBJECT.constructor'),
             define('Intl.constructor', INTL),
-            define('[].entries.constructor', ARRAY_ITERATOR),
+            define('[].entries().constructor', ARRAY_ITERATOR),
         ],
         RegExp:
         [


### PR DESCRIPTION
afaik, constructor of array iterator ([].entries()) is Object(), same as INTL and plain object, so I used array iterator as a method to get "O"