### PR TITLE
new definition of "#"

### DIFF
--- a/src/lib/definitions.js
+++ b/src/lib/definitions.js
@@ -673,6 +673,7 @@ function getFHPaddingEntries(index)
         [
             define('document.nodeName[0]',ANY_DOCUMENT),
             defineCharDefault(),
+        ]
         // '$':    ,
         '%':
         [

--- a/src/lib/definitions.js
+++ b/src/lib/definitions.js
@@ -669,7 +669,10 @@ function getFHPaddingEntries(index)
         [
             define('"".fontcolor()[12]'),
         ],
-        // '#':    ,
+        '#':
+        [
+            define('document.nodeName[0]',ANY_DOCUMENT),
+            defineCharDefault(),
         // '$':    ,
         '%':
         [


### PR DESCRIPTION
afaik, document.nodeName returns "#document"(itself is a String), so document.nodeName[0]  is "#". it would work when feature ANY_DOCUMENT active but only practical as an optimization in IE9(where is no atob()).