### PR TITLE
Added DOMWINDOW related definitions

### DIFF
--- a/src/lib/definitions.js
+++ b/src/lib/definitions.js
@@ -673,7 +673,7 @@ function getFHPaddingEntries(index)
         [
             define('document.nodeName[0]',ANY_DOCUMENT),
             defineCharDefault(),
-        ]
+        ],
         // '$':    ,
         '%':
         [
@@ -793,6 +793,7 @@ function getFHPaddingEntries(index)
             define('escape(true + AT)[50]', AT, V8_SRC),
             define('escape(FILL)[60]', FF_SRC, FILL),
             define('escape(FLAT)[60]', FF_SRC, FLAT),
+            define('(RP_3_WA + self)[11]', DOMWINDOW),
         ],
         'E':
         [
@@ -849,6 +850,7 @@ function getFHPaddingEntries(index)
             define('(RP_4_A + Date())[30]', GMT),
             define('(RP_0_S + Audio)[11]', HTMLAUDIOELEMENT),
             define('(RP_0_S + document)[10]', HTMLDOCUMENT),
+            define('(RP_0_S + self)[10]', DOMWINDOW),
         ],
         'N': '"NaN"[0]',
         'O':
@@ -858,6 +860,7 @@ function getFHPaddingEntries(index)
             define('btoa(NaN)[3]', ATOB),
             define('"".fontcolor()[2]', CAPITAL_HTML),
             define('(RP_3_WA + Intl)[11]', PLAIN_INTL),
+            define('(RP_1_WA + self)[10]', DOMWINDOW),
         ],
         'P':
         [


### PR DESCRIPTION
afaik, letters "D","O" and "M" can be also extracted from string "[object DOMWindow]", so I added 3 new definitions work when the feature `DOMWINDOW` available. 