### PR TITLE
New Features about `Number.prototype.toLocaleString()` for IE11 in win7 and 8, a lot of related new definitions (reopened again)

### DIFF
--- a/src/lib/definitions.js
+++ b/src/lib/definitions.js
@@ -525,13 +525,23 @@ function getFHPaddingEntries(index)
         var expr = '(' + number + ')[TO_LOCALE_STRING](' + locale + ')';
         if (index != null)
         {
-            if (index > 4)
+            if (index > 4 && index < 10)
             {
-                var paddingBlock = R_PADDINGS[10 - index];
-                expr = '(' + paddingBlock + ' + ' + expr + ')[10]';
+                var padding;
+                var shiftedIndex;
+                if (index === 8)
+                {
+                    padding = 3;
+                    shiftedIndex = 11;
+                }
+                else
+                {
+                    padding = 10 - index;
+                    shiftedIndex = 10;
+                }
+                var paddingBlock = R_PADDINGS[padding];
+                expr = '(' + paddingBlock + ' + ' + expr + ')[' + shiftedIndex + ']';
             }
-            else
-                expr += '[' + index + ']';
         }
         var entry = define._callWithFeatures(expr, LOCALE_NUMERALS, arguments, 3);
         return entry;
@@ -2654,7 +2664,7 @@ function getFHPaddingEntries(index)
     useLocaleNumeralDefinition('ا', '"ar"', Infinity, 2, LOCALE_NUMERALS_IE11_WIN7_8);
     useLocaleNumeralDefinition('ن', '"ar"', Infinity, 4, LOCALE_NUMERALS_IE11_WIN7_8);
     useLocaleNumeralDefinition('ه', '"ar"', Infinity, 5, LOCALE_NUMERALS_IE11_WIN7_8);
-    useLocaleNumeralDefinition('ﺓ', '"ar"', Infinity, 8, LOCALE_NUMERALS_IE11_WIN7_8);
+    useLocaleNumeralDefinition('ة', '"ar"', Infinity, 8, LOCALE_NUMERALS_IE11_WIN7_8);
     useLocaleNumeralDigitDefinitions('"bn"', 0x09e6, LOCALE_NUMERALS_EXT);
     useLocaleNumeralDefinition('č', '"cs"', NaN, 5, LOCALE_NUMERALS_IE11_WIN7_8);
     useLocaleNumeralDefinition('μ', '"el"', NaN, 0, LOCALE_NUMERALS_IE11_WIN7_8);

--- a/src/lib/definitions.js
+++ b/src/lib/definitions.js
@@ -542,6 +542,8 @@ function getFHPaddingEntries(index)
                 var paddingBlock = R_PADDINGS[padding];
                 expr = '(' + paddingBlock + ' + ' + expr + ')[' + shiftedIndex + ']';
             }
+            else
+                expr += '[' + index + ']';
         }
         var entry = define._callWithFeatures(expr, LOCALE_NUMERALS, arguments, 3);
         return entry;

--- a/src/lib/definitions.js
+++ b/src/lib/definitions.js
@@ -386,6 +386,9 @@ function getFHPaddingEntries(index)
     var LOCALE_INFINITY                 = Feature.LOCALE_INFINITY;
     var LOCALE_NUMERALS                 = Feature.LOCALE_NUMERALS;
     var LOCALE_NUMERALS_EXT             = Feature.LOCALE_NUMERALS_EXT;
+    var LOCALE_NUMERALS_IE11_WIN7       = Feature.LOCALE_NUMERALS_IE11_WIN7;
+    var LOCALE_NUMERALS_IE11_WIN7_8     = Feature.LOCALE_NUMERALS_IE11_WIN7_8;
+    var LOCALE_NUMERALS_IE11_WIN8       = Feature.LOCALE_NUMERALS_IE11_WIN8;
     var LOCATION                        = Feature.LOCATION;
     var MOZILLA                         = Feature.MOZILLA;
     var NAME                            = Feature.NAME;
@@ -1321,6 +1324,8 @@ function getFHPaddingEntries(index)
         '∞':
         [
             define('Infinity[TO_LOCALE_STRING]()', LOCALE_INFINITY),
+            define('Infinity[TO_LOCALE_STRING]("ja")[1]', LOCALE_NUMERALS_IE11_WIN7_8),
+            define('Infinity[TO_LOCALE_STRING]("ru")', LOCALE_NUMERALS_IE11_WIN8),
             define('Infinity[TO_LOCALE_STRING]("ja")[SLICE_OR_SUBSTR]("-1")', JAPANESE_INFINITY),
             define('Infinity[TO_LOCALE_STRING]("ja").at("-1")', JAPANESE_INFINITY, AT),
             defineCharDefault(),
@@ -2640,15 +2645,43 @@ function getFHPaddingEntries(index)
     useLocaleNumeralDefinition('ي', '"ar"', NaN, 1);
     useLocaleNumeralDefinition('س', '"ar"', NaN, 2);
     useLocaleNumeralDefinition('ر', '"ar"', NaN, 4, LOCALE_NUMERALS_EXT);
+    useLocaleNumeralDefinition('ب', '"ar"', NaN, 4, LOCALE_NUMERALS_IE11_WIN7_8);
     useLocaleNumeralDefinition('ق', '"ar"', NaN, 5, LOCALE_NUMERALS_EXT);
+    useLocaleNumeralDefinition('ر', '"ar"', NaN, 5, LOCALE_NUMERALS_IE11_WIN7_8);
     useLocaleNumeralDefinition('م', '"ar"', NaN, 6, LOCALE_NUMERALS_EXT);
+    useLocaleNumeralDefinition('ق', '"ar"', NaN, 6, LOCALE_NUMERALS_IE11_WIN7_8);
+    useLocaleNumeralDefinition('م', '"ar"', NaN, 7, LOCALE_NUMERALS_IE11_WIN7_8);
+    useLocaleNumeralDefinition('ا', '"ar"', Infinity, 2, LOCALE_NUMERALS_IE11_WIN7_8);
+    useLocaleNumeralDefinition('ن', '"ar"', Infinity, 4, LOCALE_NUMERALS_IE11_WIN7_8);
+    useLocaleNumeralDefinition('ه', '"ar"', Infinity, 5, LOCALE_NUMERALS_IE11_WIN7_8);
+    useLocaleNumeralDefinition('ﺓ', '"ar"', Infinity, 8, LOCALE_NUMERALS_IE11_WIN7_8);
     useLocaleNumeralDigitDefinitions('"bn"', 0x09e6, LOCALE_NUMERALS_EXT);
+    useLocaleNumeralDefinition('č', '"cs"', NaN, 5, LOCALE_NUMERALS_IE11_WIN7_8);
+    useLocaleNumeralDefinition('μ', '"el"', NaN, 0, LOCALE_NUMERALS_IE11_WIN7_8);
+    useLocaleNumeralDefinition('η', '"el"', NaN, 1, LOCALE_NUMERALS_IE11_WIN7_8);
+    useLocaleNumeralDefinition('α', '"el"', NaN, 3, LOCALE_NUMERALS_IE11_WIN7_8);
+    useLocaleNumeralDefinition('ρ', '"el"', NaN, 4, LOCALE_NUMERALS_IE11_WIN7_8);
+    useLocaleNumeralDefinition('ι', '"el"', NaN, 5, LOCALE_NUMERALS_IE11_WIN7_8);
+    useLocaleNumeralDefinition('θ', '"el"', NaN, 6, LOCALE_NUMERALS_IE11_WIN7_8);
+    useLocaleNumeralDefinition('ό', '"el"', NaN, 8, LOCALE_NUMERALS_IE11_WIN7_8);
+    useLocaleNumeralDefinition('ς', '"el"', NaN, 9, LOCALE_NUMERALS_IE11_WIN7_8);
+    useLocaleNumeralDefinition('Ά', '"el"', Infinity, 0, LOCALE_NUMERALS_IE11_WIN7_8);
+    useLocaleNumeralDefinition('π', '"el"', Infinity, 1, LOCALE_NUMERALS_IE11_WIN7_8);
+    useLocaleNumeralDefinition('ε', '"el"', Infinity, 2, LOCALE_NUMERALS_IE11_WIN7_8);
+    useLocaleNumeralDefinition('ο', '"el"', Infinity, 5, LOCALE_NUMERALS_IE11_WIN7_8);
     useLocaleNumeralDigitDefinitions('"fa"', 0x06f0);
     useLocaleNumeralDefinition('٬', '"fa"', 1000, 1);
     useLocaleNumeralDefinition('ن', '"fa"', NaN, 0, LOCALE_NUMERALS_EXT);
     useLocaleNumeralDefinition('ا', '"fa"', NaN, 1, LOCALE_NUMERALS_EXT);
     useLocaleNumeralDefinition('ع', '"fa"', NaN, 2, LOCALE_NUMERALS_EXT);
     useLocaleNumeralDefinition('د', '"fa"', NaN, 3, LOCALE_NUMERALS_EXT);
+    useLocaleNumeralDefinition('ל', '"he"', NaN, 0, LOCALE_NUMERALS_IE11_WIN7_8);
+    useLocaleNumeralDefinition('非', '"ja"', NaN, 5, LOCALE_NUMERALS_IE11_WIN7_8);
+    useLocaleNumeralDefinition('数', '"ja"', NaN, 6, LOCALE_NUMERALS_IE11_WIN7_8);
+    useLocaleNumeralDefinition('値', '"ja"', NaN, 7, LOCALE_NUMERALS_IE11_WIN7_8);
+    useLocaleNumeralDefinition('ė', '"lt"', Infinity, 7, LOCALE_NUMERALS_IE11_WIN7);
+    useLocaleNumeralDefinition('ī', '"lv"', Infinity, 6, LOCALE_NUMERALS_IE11_WIN7_8);
+    useLocaleNumeralDefinition('ś', '"pl"', Infinity, 13, LOCALE_NUMERALS_IE11_WIN7_8);
     useLocaleNumeralDefinition('н', '"ru"', NaN, 0, LOCALE_NUMERALS_EXT);
     useLocaleNumeralDefinition('е', '"ru"', NaN, 1, LOCALE_NUMERALS_EXT);
     useLocaleNumeralDefinition('ч', '"ru"', NaN, 3, LOCALE_NUMERALS_EXT);
@@ -2656,5 +2689,17 @@ function getFHPaddingEntries(index)
     useLocaleNumeralDefinition('с', '"ru"', NaN, 5, LOCALE_NUMERALS_EXT);
     useLocaleNumeralDefinition('л', '"ru"', NaN, 6, LOCALE_NUMERALS_EXT);
     useLocaleNumeralDefinition('о', '"ru"', NaN, 7, LOCALE_NUMERALS_EXT);
+    useLocaleNumeralDefinition('б', '"ru"', Infinity, 0, LOCALE_NUMERALS_IE11_WIN7);
+    useLocaleNumeralDefinition('е', '"ru"', Infinity, 1, LOCALE_NUMERALS_IE11_WIN7);
+    useLocaleNumeralDefinition('с', '"ru"', Infinity, 2, LOCALE_NUMERALS_IE11_WIN7);
+    useLocaleNumeralDefinition('к', '"ru"', Infinity, 3, LOCALE_NUMERALS_IE11_WIN7);
+    useLocaleNumeralDefinition('н', '"ru"', Infinity, 5, LOCALE_NUMERALS_IE11_WIN7);
+    useLocaleNumeralDefinition('ч', '"ru"', Infinity, 7, LOCALE_NUMERALS_IE11_WIN7);
+    useLocaleNumeralDefinition('о', '"ru"', Infinity, 9, LOCALE_NUMERALS_IE11_WIN7);
+    useLocaleNumeralDefinition('т', '"ru"', Infinity, 11, LOCALE_NUMERALS_IE11_WIN7);
+    useLocaleNumeralDefinition('ь', '"ru"', Infinity, 12, LOCALE_NUMERALS_IE11_WIN7);
+    useLocaleNumeralDefinition('正', '"zh"', Infinity, 0, LOCALE_NUMERALS_IE11_WIN7_8);
+    useLocaleNumeralDefinition('字', '"zh-cn"', NaN, 2, LOCALE_NUMERALS_IE11_WIN7_8);
+}
 }
 )();

--- a/src/lib/definitions.js
+++ b/src/lib/definitions.js
@@ -2701,5 +2701,4 @@ function getFHPaddingEntries(index)
     useLocaleNumeralDefinition('正', '"zh"', Infinity, 0, LOCALE_NUMERALS_IE11_WIN7_8);
     useLocaleNumeralDefinition('字', '"zh-cn"', NaN, 2, LOCALE_NUMERALS_IE11_WIN7_8);
 }
-}
 )();

--- a/src/lib/definitions.js
+++ b/src/lib/definitions.js
@@ -2691,8 +2691,8 @@ function getFHPaddingEntries(index)
     useLocaleNumeralDefinition('非', '"ja"', NaN, 5, LOCALE_NUMERALS_IE11_WIN7_8);
     useLocaleNumeralDefinition('数', '"ja"', NaN, 6, LOCALE_NUMERALS_IE11_WIN7_8);
     useLocaleNumeralDefinition('値', '"ja"', NaN, 7, LOCALE_NUMERALS_IE11_WIN7_8);
-    useLocaleNumeralDefinition('ė', '"lt"', Infinity, 7, LOCALE_NUMERALS_IE11_WIN7);
-    useLocaleNumeralDefinition('ī', '"lv"', Infinity, 6, LOCALE_NUMERALS_IE11_WIN7_8);
+    useLocaleNumeralDefinition('ė', '"lt"', Infinity, 7, LOCALE_NUMERALS_IE11_WIN7_8);
+    useLocaleNumeralDefinition('ī', '"lv"', Infinity, 6, LOCALE_NUMERALS_IE11_WIN7);
     useLocaleNumeralDefinition('ś', '"pl"', Infinity, 13, LOCALE_NUMERALS_IE11_WIN7_8);
     useLocaleNumeralDefinition('н', '"ru"', NaN, 0, LOCALE_NUMERALS_EXT);
     useLocaleNumeralDefinition('е', '"ru"', NaN, 1, LOCALE_NUMERALS_EXT);

--- a/src/lib/features.js
+++ b/src/lib/features.js
@@ -580,6 +580,7 @@ var featureInfos =
             return available;
         },
         includes: ['LOCALE_NUMERALS'],
+        excludes: ['LOCALE_NUMERALS_IE11_WIN7_8'],
     },
     LOCALE_NUMERALS_IE11_WIN7:
     {
@@ -620,6 +621,7 @@ var featureInfos =
             var available =
             checkLocaleNumeral('ar', NaN, /^ليس.برقم/) &&
             checkLocaleNumeral('ar', Infinity, /^\+لا.نهاية/) &&
+            checkLocaleNumeral('ar-td', 234567890.1, /^٢٣٤٬?٥٦٧٬?٨٩٠٫١/) &&
             checkLocaleNumeral('cs', NaN, /^Není.číslo/) &&
             checkLocaleNumeral('el', Infinity, /^Άπειρο/) &&
             checkLocaleNumeral('el', NaN, /^μη.αριθμός/) &&

--- a/src/lib/features.js
+++ b/src/lib/features.js
@@ -581,6 +581,77 @@ var featureInfos =
         },
         includes: ['LOCALE_NUMERALS'],
     },
+    LOCALE_NUMERALS_IE11_WIN7:
+    {
+        description:
+        'Localized number formatting exclusive to Interner Explorer 11 in Windows 7.\n' +
+        'This includes the letters in the Latvian string representation of Infinity ' +
+        '("bezgalība") and the letters in the Russian string representation of Infinity ' +
+        '("бесконечность").',
+        check:
+        function ()
+        {
+            var available =
+            checkLocaleNumeral('lv', Infinity, /^bezgalība/) &&
+            checkLocaleNumeral('ru', Infinity, /^бесконечность/);
+            return available;
+        },
+        includes: ['LOCALE_NUMERALS_IE11_WIN7_8'],
+        excludes: ['LOCALE_NUMERALS_IE11_WIN8'],
+    },
+    LOCALE_NUMERALS_IE11_WIN7_8:
+    {
+        description:
+        'Localized number formatting exclusive to Interner Explorer 11 in Windows 7 and 8.\n' +
+        'This includes all features of LOCALE_NUMERALS plus the output of the letters in the ' +
+        'second word of the Arabic string representation of NaN ("برقم"), the letters in the ' +
+        'Arabic string representation of Infinity ("+لا\xa0نهاية"), the letters in the the Czech ' +
+        'string representation of NaN ("Není\xa0číslo"), the letters in the the Greek string ' +
+        'representation of Infinity ("Άπειρο"), the letters in the Greek string representation ' +
+        'of NaN ("μη\xa0αριθμός"), the letters in the Hebrew string representation of NaN ' +
+        '("לא\xa0מספר"), the characters in the Japanese string representation of Infinity ' +
+        '("+∞"), the characters in the Japanese string representation of NaN ("NaN\xa0(非数値)"), ' +
+        'the letters in the Lithuanian string representation of Infinity ("begalybė"), the ' +
+        'letters in the Polish string representation of Infinity ("+nieskończoność"), the ' +
+        'characters in the Chinese string representation of Infinity ("正无穷大" or "正無窮大"), the ' +
+        'characters in the Simplified Chinese string representation of NaN ("非数字").',
+        check:
+        function ()
+        {
+            var available =
+            checkLocaleNumeral('ar', NaN, /^ليس.برقم/) &&
+            checkLocaleNumeral('ar', Infinity, /^\+لا.نهاية/) &&
+            checkLocaleNumeral('ar-td', 234567890.1, /^٢٣٤٬?٥٦٧٬?٨٩٠٫١/) &&
+            checkLocaleNumeral('cs', NaN, /^Není.číslo/) &&
+            checkLocaleNumeral('el', Infinity, /^Άπειρο/) &&
+            checkLocaleNumeral('el', NaN, /^μη.αριθμός/) &&
+            checkLocaleNumeral('he', NaN, /^לא.מספר/) &&
+            checkLocaleNumeral('ja', Infinity, /^\+∞/) &&
+            checkLocaleNumeral('ja', NaN, /^NaN \(非数値\)/) &&
+            checkLocaleNumeral('lt', Infinity, /^begalybė/) &&
+            checkLocaleNumeral('pl', Infinity, /^\+nieskończoność/) &&
+            checkLocaleNumeral('zh', Infinity, /^正/) &&
+            checkLocaleNumeral('zh-cn', NaN, /^非数字/);
+            return available;
+        },
+        includes: ['LOCALE_NUMERALS'],
+        excludes: ['LOCALE_NUMERALS_EXT'],
+    },
+    LOCALE_NUMERALS_IE11_WIN8:
+    {
+        description:
+        'Localized number formatting exclusive to Interner Explorer 11 in Windows 8.\n' +
+        'In this case, Latvian and Russian string representation of Infinity are both "∞".',
+        check:
+        function ()
+        {
+            var available = Infinity.toLocaleString('lv') === '∞' &&
+            Infinity.toLocaleString('ru') === '∞';
+            return available;
+        },
+        includes: ['LOCALE_NUMERALS_IE11_WIN7_8'],
+        excludes: ['LOCALE_NUMERALS_IE11_WIN7'],
+    },
     LOCATION:
     {
         description:
@@ -1128,23 +1199,39 @@ var featureInfos =
         versions: ['11'],
         includes:
         {
-            ANY_DOCUMENT:       true,
-            DOCUMENT:           false,
-            GMT:                true,
-            JAPANESE_INFINITY:  true,
-            LOCALE_NUMERALS:    true,
-            PLAIN_INTL:         true,
-            SHORT_LOCALES:      true,
+            ANY_DOCUMENT:                true,
+            DOCUMENT:                    false,
+            GMT:                         true,
+            JAPANESE_INFINITY:           true,
+            LOCALE_NUMERALS:             true,
+            LOCALE_NUMERALS_IE11_WIN7:   true,
+            LOCALE_NUMERALS_IE11_WIN7_8: true,
+            PLAIN_INTL:                  true,
+            SHORT_LOCALES:               true,
         },
+    },
+    IE_11_WIN_8:
+    {
+        inherits:               'IE_11',
+        versions:               ['11'],
+        compatibilityTag:       'on Windows 8',
+        compatibilityShortTag:  'W8',
+        includes:
+        { LOCALE_NUMERALS_IE11_WIN7: false, LOCALE_NUMERALS_IE11_WIN8: true },
     },
     IE_11_WIN_10:
     {
-        inherits:               'IE_11',
+        inherits:               'IE_11_WIN_8',
         versions:               ['11'],
         compatibilityTag:       'on Windows 10',
         compatibilityShortTag:  'W10',
         includes:
-        { LOCALE_INFINITY: true, LOCALE_NUMERALS: false, LOCALE_NUMERALS_EXT: true },
+        {
+            LOCALE_INFINITY:             true,
+            LOCALE_NUMERALS_EXT:         true,
+            LOCALE_NUMERALS_IE11_WIN7_8: false,
+            LOCALE_NUMERALS_IE11_WIN8:   false,
+        },
     },
     NODE_0_10:
     {

--- a/src/lib/features.js
+++ b/src/lib/features.js
@@ -542,23 +542,6 @@ var featureInfos =
             return available;
         },
     },
-        LOCALE_INFINITY_IE11_WIN7:
-    {
-        description:
-        'Localized string representation of Infinity exclusive to Interner Explorer 11 in' +
-        ' Windows 7.\n' +
-        'This includes Latvian ("bezgalība") and Russian ("бесконечность").',
-        check:
-        function ()
-        {
-            var available =
-            checkLocaleNumeral('lv', Infinity, /^bezgalība/) &&
-            checkLocaleNumeral('ru', Infinity, /^бесконечность/);
-            return available;
-        },
-        includes: ['LOCALE_NUMERALS_IE11_WIN7_8'],
-        excludes: ['LOCALE_INFINITY_IE11_WIN7'],
-    },
     LOCALE_NUMERALS:
     {
         description:
@@ -597,6 +580,23 @@ var featureInfos =
             return available;
         },
         includes: ['LOCALE_NUMERALS'],
+    },
+    LOCALE_NUMERALS_IE11_WIN7:
+    {
+        description:
+        'Localized number formatting exclusive to Interner Explorer 11 in Windows 7.\n' +
+        'This includes string representation of Infinity ("bezgalība") and string ' +
+        'representation of Infinity ("бесконечность").',
+        check:
+        function ()
+        {
+            var available =
+            checkLocaleNumeral('lv', Infinity, /^bezgalība/) &&
+            checkLocaleNumeral('ru', Infinity, /^бесконечность/);
+            return available;
+        },
+        includes: ['LOCALE_NUMERALS_IE11_WIN7_8'],
+        excludes: ['LOCALE_INFINITY_IE11_WIN7'],
     },
     LOCALE_NUMERALS_IE11_WIN7_8:
     {

--- a/src/lib/features.js
+++ b/src/lib/features.js
@@ -542,6 +542,23 @@ var featureInfos =
             return available;
         },
     },
+        LOCALE_INFINITY_IE11_WIN7:
+    {
+        description:
+        'Localized string representation of Infinity exclusive to Interner Explorer 11 in' +
+        ' Windows 7.\n' +
+        'This includes Latvian ("bezgalība") and Russian ("бесконечность").',
+        check:
+        function ()
+        {
+            var available =
+            checkLocaleNumeral('lv', Infinity, /^bezgalība/) &&
+            checkLocaleNumeral('ru', Infinity, /^бесконечность/);
+            return available;
+        },
+        includes: ['LOCALE_NUMERALS_IE11_WIN7_8'],
+        excludes: ['LOCALE_INFINITY_IE11_WIN7'],
+    },
     LOCALE_NUMERALS:
     {
         description:
@@ -581,24 +598,6 @@ var featureInfos =
         },
         includes: ['LOCALE_NUMERALS'],
     },
-    LOCALE_NUMERALS_IE11_WIN7:
-    {
-        description:
-        'Localized number formatting exclusive to Interner Explorer 11 in Windows 7.\n' +
-        'This includes the letters in the Latvian string representation of Infinity ' +
-        '("bezgalība") and the letters in the Russian string representation of Infinity ' +
-        '("бесконечность").',
-        check:
-        function ()
-        {
-            var available =
-            checkLocaleNumeral('lv', Infinity, /^bezgalība/) &&
-            checkLocaleNumeral('ru', Infinity, /^бесконечность/);
-            return available;
-        },
-        includes: ['LOCALE_NUMERALS_IE11_WIN7_8'],
-        excludes: ['LOCALE_NUMERALS_IE11_WIN8'],
-    },
     LOCALE_NUMERALS_IE11_WIN7_8:
     {
         description:
@@ -621,7 +620,6 @@ var featureInfos =
             var available =
             checkLocaleNumeral('ar', NaN, /^ليس.برقم/) &&
             checkLocaleNumeral('ar', Infinity, /^\+لا.نهاية/) &&
-            checkLocaleNumeral('ar-td', 234567890.1, /^٢٣٤٬?٥٦٧٬?٨٩٠٫١/) &&
             checkLocaleNumeral('cs', NaN, /^Není.číslo/) &&
             checkLocaleNumeral('el', Infinity, /^Άπειρο/) &&
             checkLocaleNumeral('el', NaN, /^μη.αριθμός/) &&

--- a/test/helpers/feature-emulation.helpers.js
+++ b/test/helpers/feature-emulation.helpers.js
@@ -1135,12 +1135,18 @@
                     {
                     case 'ar':
                     case 'ar-td':
-                        switch (+this) // In Internet Explorer 9, +this is different from this.
+                        number = Number(this);
+                        if (isNaN(number))
+                            returnValue = 'ليس\xa0برقم';
+                        else
                         {
-                        case Infinity:
-                            return '+لا\xa0نهاية';
-                        case -Infinity:
-                            return '-لا\xa0نهاية';
+                            switch (+this) // In Internet Explorer 9, +this is different from this.
+                            {
+                            case Infinity:
+                                return '+لا\xa0نهاية';
+                            case -Infinity:
+                                return '-لا\xa0نهاية';
+                            }
                         }
                         break;
                     case 'cz':

--- a/test/helpers/feature-emulation.helpers.js
+++ b/test/helpers/feature-emulation.helpers.js
@@ -1135,7 +1135,6 @@
                     switch (locale)
                     {
                     case 'ar':
-                    case 'ar-td':
                         if (isNaN(number))
                             returnValue = 'ليس\xa0برقم';
                         else

--- a/test/helpers/feature-emulation.helpers.js
+++ b/test/helpers/feature-emulation.helpers.js
@@ -1138,6 +1138,7 @@
                         number = Number(this);
                         if (isNaN(number))
                             returnValue = 'ليس\xa0برقم';
+                        break;
                         else
                         {
                             switch (+this) // In Internet Explorer 9, +this is different from this.

--- a/test/helpers/feature-emulation.helpers.js
+++ b/test/helpers/feature-emulation.helpers.js
@@ -1144,8 +1144,10 @@
                             {
                             case Infinity:
                                 returnValue = '+لا\xa0نهاية';
+                                break;
                             case -Infinity:
                                 returnValue = '-لا\xa0نهاية';
+                                break;
                             }
                         }
                         break;
@@ -1162,8 +1164,10 @@
                             {
                             case Infinity:
                                 returnValue = 'Άπειρο';
+                                break;
                             case -Infinity:
                                 returnValue = '-Άπειρο';
+                                break;
                             }
                         }
                         break;
@@ -1180,8 +1184,10 @@
                             {
                             case Infinity:
                                 returnValue = '+∞';
+                                break;
                             case -Infinity:
                                 returnValue = '-∞';
+                                break;
                             }
                         }
                         break;
@@ -1190,8 +1196,10 @@
                         {
                         case Infinity:
                             returnValue = 'begalybė';
+                            break;
                         case -Infinity:
                             returnValue = '-begalybė';
+                            break;
                         }
                         break;
                     case 'pl':
@@ -1199,8 +1207,10 @@
                         {
                         case Infinity:
                             returnValue = '+nieskończoność';
+                            break;
                         case -Infinity:
                             returnValue = '-nieskończoność';
+                            break;
                         }
                         break;
                     case 'zh':
@@ -1208,8 +1218,10 @@
                         {
                         case Infinity:
                             returnValue = '正无穷大';
+                            break;
                         case -Infinity:
                             returnValue = '负无穷大';
+                            break;
                         }
                         break;
                     case 'zh-cn':

--- a/test/helpers/feature-emulation.helpers.js
+++ b/test/helpers/feature-emulation.helpers.js
@@ -1137,57 +1137,51 @@
                     case 'ar':
                     case 'ar-td':
                         if (isNaN(number))
-                            return 'ليس\xa0برقم';
+                            returnValue = 'ليس\xa0برقم';
                         else
                         {
                             switch (+this) // In Internet Explorer 9, +this is different from this.
                             {
                             case Infinity:
-                                return '+لا\xa0نهاية';
-                                break;
+                                returnValue = '+لا\xa0نهاية';
                             case -Infinity:
-                                return '-لا\xa0نهاية';
-                                break;
+                                returnValue = '-لا\xa0نهاية';
                             }
                         }
                         break;
                     case 'cz':
                         if (isNaN(number))
-                            return 'Není\xa0číslo';
+                            returnValue = 'Není\xa0číslo';
                         break;
                     case 'el':
                         if (isNaN(number))
-                            return 'μη\xa0αριθμός';
+                            returnValue = 'μη\xa0αριθμός';
                         else
                         {
                             switch (+this) // In Internet Explorer 9, +this is different from this.
                             {
                             case Infinity:
-                                return 'Άπειρο';
-                                break;
+                                returnValue = 'Άπειρο';
                             case -Infinity:
-                                return '-Άπειρο';
-                                break;
+                                returnValue = '-Άπειρο';
                             }
                         }
                         break;
                     case 'he':
                         if (isNaN(number))
-                            return 'לא\xa0מספר';
+                            returnValue = 'לא\xa0מספר';
                         break;
                     case 'ja':
                         if (isNaN(number))
-                            return 'NaN\xa0(非数値)';
+                            returnValue = 'NaN\xa0(非数値)';
                         else
                         {
                             switch (+this) // In Internet Explorer 9, +this is different from this.
                             {
                             case Infinity:
-                                return '+∞';
-                                break;
+                                returnValue = '+∞';
                             case -Infinity:
-                                return '-∞';
-                                break;
+                                returnValue = '-∞';
                             }
                         }
                         break;
@@ -1195,38 +1189,32 @@
                         switch (+this) // In Internet Explorer 9, +this is different from this.
                         {
                         case Infinity:
-                            return 'begalybė';
-                            break;
+                            returnValue = 'begalybė';
                         case -Infinity:
-                            return '-begalybė';
-                            break;
+                            returnValue = '-begalybė';
                         }
                         break;
                     case 'pl':
                         switch (+this) // In Internet Explorer 9, +this is different from this.
                         {
                         case Infinity:
-                            return '+nieskończoność';
-                            break;
+                            returnValue = '+nieskończoność';
                         case -Infinity:
-                            return '-nieskończoność';
-                            break;
+                            returnValue = '-nieskończoność';
                         }
                         break;
                     case 'zh':
                         switch (+this) // In Internet Explorer 9, +this is different from this.
                         {
                         case Infinity:
-                            return '正无穷大';
-                            break;
+                            returnValue = '正无穷大';
                         case -Infinity:
-                            return '负无穷大';
-                            break;
+                            returnValue = '负无穷大';
                         }
                         break;
                     case 'zh-cn':
                         if (isNaN(number))
-                            return '非数字';
+                            returnValue = '非数字';
                         break;
                     }
                     return returnValue;

--- a/test/helpers/feature-emulation.helpers.js
+++ b/test/helpers/feature-emulation.helpers.js
@@ -1086,6 +1086,183 @@
                 }
             );
         },
+        LOCALE_NUMERALS_IE11_WIN7:
+        function ()
+        {
+            registerNumberToLocaleStringAdapter
+            (
+                this,
+                function (locale)
+                {
+                    var returnValue;
+                    switch (locale)
+                    {
+                    case 'lv':
+                        switch (+this) // In Internet Explorer 9, +this is different from this.
+                        {
+                        case Infinity:
+                            return 'bezgalība';
+                        case -Infinity:
+                            return '-bezgalība';
+                        }
+                        break;
+                    case 'ru':
+                        switch (+this) // In Internet Explorer 9, +this is different from this.
+                        {
+                        case Infinity:
+                            return 'бесконечность';
+                        case -Infinity:
+                            return '-бесконечность';
+                        }
+                        break;
+                    }
+                    return returnValue;
+                }
+            );
+        },
+        LOCALE_NUMERALS_IE11_WIN7_8:
+        function ()
+        {
+            this.arabicNaNString = 'ليس\xa0برقم';
+            registerNumberToLocaleStringAdapter
+            (
+                this,
+                function (locale)
+                {
+                    var returnValue;
+                    var number;
+                    switch (locale)
+                    {
+                    case 'ar':
+                    case 'ar-td':
+                        switch (+this) // In Internet Explorer 9, +this is different from this.
+                        {
+                        case Infinity:
+                            return '+لا\xa0نهاية';
+                        case -Infinity:
+                            return '-لا\xa0نهاية';
+                        }
+                        break;
+                    case 'cz':
+                        number = Number(this);
+                        if (isNaN(number))
+                            returnValue = 'Není\xa0číslo';
+                        break;
+                    case 'el':
+                        number = Number(this);
+                        if (isNaN(number))
+                            returnValue = 'μη\xa0αριθμός';
+                        else
+                        {
+                            switch (+this) // In Internet Explorer 9, +this is different from this.
+                            {
+                            case Infinity:
+                                return 'Άπειρο';
+                            case -Infinity:
+                                return '-Άπειρο';
+                            }
+                        }
+                        break;
+                    case 'he':
+                        number = Number(this);
+                        if (isNaN(number))
+                            returnValue = 'לא\xa0מספר';
+                        break;
+                    case 'ja':
+                        number = Number(this);
+                        if (isNaN(number))
+                            returnValue = 'NaN\xa0(非数値)';
+                        else
+                        {
+                            switch (+this) // In Internet Explorer 9, +this is different from this.
+                            {
+                            case Infinity:
+                                return '+∞';
+                            case -Infinity:
+                                return '-∞';
+                            }
+                        }
+                        break;
+                    case 'lt':
+                        switch (+this) // In Internet Explorer 9, +this is different from this.
+                        {
+                        case Infinity:
+                            return 'begalybė';
+                        case -Infinity:
+                            return '-begalybė';
+                        }
+                        break;
+                    case 'pl':
+                        switch (+this) // In Internet Explorer 9, +this is different from this.
+                        {
+                        case Infinity:
+                            return '+nieskończoność';
+                        case -Infinity:
+                            return '-nieskończoność';
+                        }
+                        break;
+                    case 'ru':
+                        switch (+this) // In Internet Explorer 9, +this is different from this.
+                        {
+                        case Infinity:
+                            return 'бесконечность';
+                        case -Infinity:
+                            return '-бесконечность';
+                        }
+                        break;
+                    case 'zh':
+                        switch (+this) // In Internet Explorer 9, +this is different from this.
+                        {
+                        case Infinity:
+                            return '正无穷大';
+                        case -Infinity:
+                            return '负无穷大';
+                        }
+                        break;
+                    case 'zh-cn':
+                        number = Number(this);
+                        if (isNaN(number))
+                            returnValue = '非数字';
+                        break;
+                    }
+                    return returnValue;
+                }
+            );
+        },
+        LOCALE_NUMERALS_IE11_WIN8:
+        function ()
+        {
+            registerNumberToLocaleStringAdapter
+            (
+                this,
+                function (locale)
+                {
+                    var returnValue;
+                    switch (locale)
+                    {
+                    case 'lv':
+                        switch (+this) // In Internet Explorer 9, +this is different from this.
+                        {
+                        case Infinity:
+                            return '∞';
+                        case -Infinity:
+                            return '-∞';
+                        }
+                        break;
+                    case 'ru':
+                        switch (+this) // In Internet Explorer 9, +this is different from this.
+                        {
+                        case Infinity:
+                            return '∞';
+                        case -Infinity:
+                            return '-∞';
+                        }
+                        break;
+                    }
+                    return returnValue;
+                }
+            );
+        },
         LOCATION:
         function ()
         {

--- a/test/helpers/feature-emulation.helpers.js
+++ b/test/helpers/feature-emulation.helpers.js
@@ -1232,9 +1232,11 @@
                         switch (+this) // In Internet Explorer 9, +this is different from this.
                         {
                         case Infinity:
-                            return '正无穷大';
+                            returnValue = '正无穷大';
+                            break;
                         case -Infinity:
-                            return '负无穷大';
+                            returnValue = '负无穷大';
+                            break;
                         }
                         break;
                     case 'zh-cn':

--- a/test/helpers/feature-emulation.helpers.js
+++ b/test/helpers/feature-emulation.helpers.js
@@ -1213,17 +1213,6 @@
                             break;
                         }
                         break;
-                    case 'ru':
-                        switch (+this) // In Internet Explorer 9, +this is different from this.
-                        {
-                        case Infinity:
-                            return 'бесконечность';
-                            break;
-                        case -Infinity:
-                            return '-бесконечность';
-                            break;
-                        }
-                        break;
                     case 'zh':
                         switch (+this) // In Internet Explorer 9, +this is different from this.
                         {

--- a/test/helpers/feature-emulation.helpers.js
+++ b/test/helpers/feature-emulation.helpers.js
@@ -1137,56 +1137,56 @@
                     case 'ar':
                     case 'ar-td':
                         if (isNaN(number))
-                            returnValue = 'ليس\xa0برقم';
+                            return 'ليس\xa0برقم';
                         else
                         {
                             switch (+this) // In Internet Explorer 9, +this is different from this.
                             {
                             case Infinity:
-                                returnValue = '+لا\xa0نهاية';
+                                return '+لا\xa0نهاية';
                                 break;
                             case -Infinity:
-                                returnValue = '-لا\xa0نهاية';
+                                return '-لا\xa0نهاية';
                                 break;
                             }
                         }
                         break;
                     case 'cz':
                         if (isNaN(number))
-                            returnValue = 'Není\xa0číslo';
+                            return 'Není\xa0číslo';
                         break;
                     case 'el':
                         if (isNaN(number))
-                            returnValue = 'μη\xa0αριθμός';
+                            return 'μη\xa0αριθμός';
                         else
                         {
                             switch (+this) // In Internet Explorer 9, +this is different from this.
                             {
                             case Infinity:
-                                returnValue = 'Άπειρο';
+                                return 'Άπειρο';
                                 break;
                             case -Infinity:
-                                returnValue = '-Άπειρο';
+                                return '-Άπειρο';
                                 break;
                             }
                         }
                         break;
                     case 'he':
                         if (isNaN(number))
-                            returnValue = 'לא\xa0מספר';
+                            return 'לא\xa0מספר';
                         break;
                     case 'ja':
                         if (isNaN(number))
-                            returnValue = 'NaN\xa0(非数値)';
+                            return 'NaN\xa0(非数値)';
                         else
                         {
                             switch (+this) // In Internet Explorer 9, +this is different from this.
                             {
                             case Infinity:
-                                returnValue = '+∞';
+                                return '+∞';
                                 break;
                             case -Infinity:
-                                returnValue = '-∞';
+                                return '-∞';
                                 break;
                             }
                         }
@@ -1195,10 +1195,10 @@
                         switch (+this) // In Internet Explorer 9, +this is different from this.
                         {
                         case Infinity:
-                            returnValue = 'begalybė';
+                            return 'begalybė';
                             break;
                         case -Infinity:
-                            returnValue = '-begalybė';
+                            return '-begalybė';
                             break;
                         }
                         break;
@@ -1206,10 +1206,10 @@
                         switch (+this) // In Internet Explorer 9, +this is different from this.
                         {
                         case Infinity:
-                            returnValue = '+nieskończoność';
+                            return '+nieskończoność';
                             break;
                         case -Infinity:
-                            returnValue = '-nieskończoność';
+                            return '-nieskończoność';
                             break;
                         }
                         break;
@@ -1217,10 +1217,10 @@
                         switch (+this) // In Internet Explorer 9, +this is different from this.
                         {
                         case Infinity:
-                            returnValue = 'бесконечность';
+                            return 'бесконечность';
                             break;
                         case -Infinity:
-                            returnValue = '-бесконечность';
+                            return '-бесконечность';
                             break;
                         }
                         break;
@@ -1228,16 +1228,16 @@
                         switch (+this) // In Internet Explorer 9, +this is different from this.
                         {
                         case Infinity:
-                            returnValue = '正无穷大';
+                            return '正无穷大';
                             break;
                         case -Infinity:
-                            returnValue = '负无穷大';
+                            return '负无穷大';
                             break;
                         }
                         break;
                     case 'zh-cn':
                         if (isNaN(number))
-                            returnValue = '非数字';
+                            return '非数字';
                         break;
                     }
                     return returnValue;

--- a/test/helpers/feature-emulation.helpers.js
+++ b/test/helpers/feature-emulation.helpers.js
@@ -1131,14 +1131,13 @@
                 {
                     var returnValue;
                     var number;
+                    number = Number(this);
                     switch (locale)
                     {
                     case 'ar':
                     case 'ar-td':
-                        number = Number(this);
                         if (isNaN(number))
                             returnValue = 'ليس\xa0برقم';
-                        break;
                         else
                         {
                             switch (+this) // In Internet Explorer 9, +this is different from this.
@@ -1153,12 +1152,10 @@
                         }
                         break;
                     case 'cz':
-                        number = Number(this);
                         if (isNaN(number))
                             returnValue = 'Není\xa0číslo';
                         break;
                     case 'el':
-                        number = Number(this);
                         if (isNaN(number))
                             returnValue = 'μη\xa0αριθμός';
                         else
@@ -1175,12 +1172,10 @@
                         }
                         break;
                     case 'he':
-                        number = Number(this);
                         if (isNaN(number))
                             returnValue = 'לא\xa0מספר';
                         break;
                     case 'ja':
-                        number = Number(this);
                         if (isNaN(number))
                             returnValue = 'NaN\xa0(非数値)';
                         else
@@ -1241,7 +1236,6 @@
                         }
                         break;
                     case 'zh-cn':
-                        number = Number(this);
                         if (isNaN(number))
                             returnValue = '非数字';
                         break;

--- a/test/helpers/feature-emulation.helpers.js
+++ b/test/helpers/feature-emulation.helpers.js
@@ -1143,9 +1143,11 @@
                             switch (+this) // In Internet Explorer 9, +this is different from this.
                             {
                             case Infinity:
-                                return '+لا\xa0نهاية';
+                                returnValue = '+لا\xa0نهاية';
+                                break;
                             case -Infinity:
-                                return '-لا\xa0نهاية';
+                                returnValue = '-لا\xa0نهاية';
+                                break;
                             }
                         }
                         break;
@@ -1163,9 +1165,11 @@
                             switch (+this) // In Internet Explorer 9, +this is different from this.
                             {
                             case Infinity:
-                                return 'Άπειρο';
+                                returnValue = 'Άπειρο';
+                                break;
                             case -Infinity:
-                                return '-Άπειρο';
+                                returnValue = '-Άπειρο';
+                                break;
                             }
                         }
                         break;
@@ -1183,9 +1187,11 @@
                             switch (+this) // In Internet Explorer 9, +this is different from this.
                             {
                             case Infinity:
-                                return '+∞';
+                                returnValue = '+∞';
+                                break;
                             case -Infinity:
-                                return '-∞';
+                                returnValue = '-∞';
+                                break;
                             }
                         }
                         break;
@@ -1193,27 +1199,33 @@
                         switch (+this) // In Internet Explorer 9, +this is different from this.
                         {
                         case Infinity:
-                            return 'begalybė';
+                            returnValue = 'begalybė';
+                            break;
                         case -Infinity:
-                            return '-begalybė';
+                            returnValue = '-begalybė';
+                            break;
                         }
                         break;
                     case 'pl':
                         switch (+this) // In Internet Explorer 9, +this is different from this.
                         {
                         case Infinity:
-                            return '+nieskończoność';
+                            returnValue = '+nieskończoność';
+                            break;
                         case -Infinity:
-                            return '-nieskończoność';
+                            returnValue = '-nieskończoność';
+                            break;
                         }
                         break;
                     case 'ru':
                         switch (+this) // In Internet Explorer 9, +this is different from this.
                         {
                         case Infinity:
-                            return 'бесконечность';
+                            returnValue = 'бесконечность';
+                            break;
                         case -Infinity:
-                            return '-бесконечность';
+                            returnValue = '-бесконечность';
+                            break;
                         }
                         break;
                     case 'zh':


### PR DESCRIPTION
Sorry for create a PR about that the third time. What should I do about IE11 subversions?