### PR TITLE
Even further optimization of `CALL_ON_GLOBAL` definitions

### DIFF
--- a/src/lib/definitions.js
+++ b/src/lib/definitions.js
@@ -1118,7 +1118,6 @@ function getFHPaddingEntries(index)
             define('(RP_3_WA + "".slice.call())[11]', CALL_ON_GLOBAL, WINDOW),
             define('"".sub.call()[13]', CALL_ON_GLOBAL, WINDOW),
             define('("".slice.call() + RP_4_A).at("-11")', ANY_WINDOW, AT, CALL_ON_GLOBAL),
-            define('"".sub.call().at("-13")', ANY_WINDOW, AT, CALL_ON_GLOBAL),
             defineCharDefault({ atob: false }),
         ],
         'X':


### PR DESCRIPTION
I've just found some `String.prototype` method can create code of "W" and "w" shorter than `Array.prototype.concat` when `CALL_ON_GLOBAL` is active.