### PR TITLE
Rewritten checking mechanism of `ITERATOR_HELPER`

### DIFF
--- a/api-doc/interfaces/FeatureAll.md
+++ b/api-doc/interfaces/FeatureAll.md
@@ -382,7 +382,7 @@ Available in Chrome, Edge, Firefox, Internet Explorer, Safari, Opera, and Node.j
 
 > **ITERATOR\_HELPER**: [`ElementaryFeature`](ElementaryFeature.md)
 
-Availability of iterator helpers.
+Availability of iterator helpers, whom string representation evaluates to "\[object Iterator Helper\]".
 
 #### Remarks
 

--- a/api-doc/interfaces/FeatureAll.md
+++ b/api-doc/interfaces/FeatureAll.md
@@ -382,7 +382,7 @@ Available in Chrome, Edge, Firefox, Internet Explorer, Safari, Opera, and Node.j
 
 > **ITERATOR\_HELPER**: [`ElementaryFeature`](ElementaryFeature.md)
 
-Availability of iterator helpers, whom string representation evaluates to "\[object Iterator Helper\]".
+Availability of iterator helpers having the string representation "\[object Iterator Helper\]".
 
 #### Remarks
 

--- a/api-doc/interfaces/FeatureConstructor.md
+++ b/api-doc/interfaces/FeatureConstructor.md
@@ -628,7 +628,7 @@ Available in Chrome, Edge, Firefox, Internet Explorer, Safari, Opera, and Node.j
 
 > **ITERATOR\_HELPER**: [`ElementaryFeature`](ElementaryFeature.md)
 
-Availability of iterator helpers.
+Availability of iterator helpers, whom string representation evaluates to "\[object Iterator Helper\]".
 
 #### Remarks
 

--- a/api-doc/interfaces/FeatureConstructor.md
+++ b/api-doc/interfaces/FeatureConstructor.md
@@ -628,7 +628,7 @@ Available in Chrome, Edge, Firefox, Internet Explorer, Safari, Opera, and Node.j
 
 > **ITERATOR\_HELPER**: [`ElementaryFeature`](ElementaryFeature.md)
 
-Availability of iterator helpers, whom string representation evaluates to "\[object Iterator Helper\]".
+Availability of iterator helpers having the string representation "\[object Iterator Helper\]".
 
 #### Remarks
 

--- a/src/lib/features.js
+++ b/src/lib/features.js
@@ -279,8 +279,15 @@ var featureInfos =
         check:
         function ()
         {
-            var available = [].entries().filter(Function()) + '' === '[object Iterator Helper]';
-            return available;
+            if (Array.prototype.entries)
+            {
+                if ([].entries().filter)
+                {
+                    var available = [].entries().filter(Function()) + '' ===
+                    '[object Iterator Helper]';
+                    return available;
+                }
+            }
         },
     },
     LOCALE_INFINITY:

--- a/src/lib/features.js
+++ b/src/lib/features.js
@@ -282,10 +282,10 @@ var featureInfos =
         {
             if (Array.prototype.entries)
             {
-                if ([].entries().filter)
+                var entries = [].entries();
+                if (entries.filter)
                 {
-                    var available = [].entries().filter(Function()) + '' ===
-                    '[object Iterator Helper]';
+                    var available = entries.filter(Function()) + '' === '[object Iterator Helper]';
                     return available;
                 }
             }

--- a/src/lib/features.js
+++ b/src/lib/features.js
@@ -274,11 +274,12 @@ var featureInfos =
     },
     ITERATOR_HELPER:
     {
-        description: 'Availability of iterator helpers.',
+        description: 'Availability of iterator helpers, whom string representation evaluates to ' +
+        '"[object Iterator Helper]".',
         check:
         function ()
         {
-            var available = typeof Iterator === 'function';
+            var available = [].entries().filter(Function()) + '' === '[object Iterator Helper]';
             return available;
         },
     },

--- a/src/lib/features.js
+++ b/src/lib/features.js
@@ -274,8 +274,9 @@ var featureInfos =
     },
     ITERATOR_HELPER:
     {
-        description: 'Availability of iterator helpers, whom string representation evaluates to ' +
-        '"[object Iterator Helper]".',
+        description:
+        'Availability of iterator helpers having the string representation "[object Iterator ' +
+        'Helper]".',
         check:
         function ()
         {


### PR DESCRIPTION
anyway, idk can `ITERATOR_HELPER` coexist with `OBJECT_ARRAY_ENTRIES_CTOR`, or could there be any possibility which `ITERATOR_HELPER` avaliable but [].entries()+[] even not begin with "[object".